### PR TITLE
Use Third Iron's apiconnector server as default node server

### DIFF
--- a/js/browzine.js
+++ b/js/browzine.js
@@ -1,10 +1,10 @@
 // Define Angular module and whitelist URL of server with Node.js script
 var app = angular.module('viewCustom', ['angularLoad'])
-  .constant('nodeserver', "https://yourserver.edu")
+  .constant('nodeserver', "https://apiconnector.thirdiron.com/v1/libraries/your_browzine_library_id")
   .config(['$sceDelegateProvider', 'nodeserver', function ($sceDelegateProvider, nodeserver) {
-  var urlWhitelist = $sceDelegateProvider.resourceUrlWhitelist();
-  urlWhitelist.push(nodeserver + '**');
-  $sceDelegateProvider.resourceUrlWhitelist(urlWhitelist);
+    var urlWhitelist = $sceDelegateProvider.resourceUrlWhitelist();
+    urlWhitelist.push(nodeserver + '**');
+    $sceDelegateProvider.resourceUrlWhitelist(urlWhitelist);
 }]);
 
 // Add Article In Context & BrowZine Links
@@ -13,7 +13,7 @@ var app = angular.module('viewCustom', ['angularLoad'])
     $scope.book_icon = "https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine_open_book_icon.png";
     if (vm.parentCtrl.result.pnx.addata.doi && vm.parentCtrl.result.pnx.display.type[0] == 'article')  {
           vm.doi = vm.parentCtrl.result.pnx.addata.doi[0] || '';
-          var articleURL = nodeserver + "/primo/browzine/articles?DOI=" + vm.doi;
+          var articleURL = nodeserver + "/articles?DOI=" + vm.doi;
           $http.jsonp(articleURL, {jsonpCallbackParam: 'callback'}).then(function(response) {
             $scope.article = response.data;
           }, function(error){
@@ -22,7 +22,7 @@ var app = angular.module('viewCustom', ['angularLoad'])
       }
       if (vm.parentCtrl.result.pnx.addata.issn && vm.parentCtrl.result.pnx.display.type[0] == 'journal')  {
           vm.issn = vm.parentCtrl.result.pnx.addata.issn[0].replace("-", "") || '';
-          var journalURL = nodeserver + "/primo/browzine/journals?ISSN=" + vm.issn;
+          var journalURL = nodeserver + "/journals?ISSN=" + vm.issn;
           $http.jsonp(journalURL, {jsonpCallbackParam: 'callback'}).then(function(response) {
             $scope.journal = response.data;
           }, function(error){
@@ -50,7 +50,7 @@ app.controller('prmSearchResultThumbnailContainerAfterController', function ($sc
   var newThumbnail = '';
   if (vm.parentCtrl.item.pnx.addata.issn) {
     vm.issn = vm.parentCtrl.item.pnx.addata.issn[0].replace("-", "") || '';
-    var journalURL = nodeserver + "/primo/browzine/journals?ISSN=" + vm.issn;
+    var journalURL = nodeserver + "/journals?ISSN=" + vm.issn;
     $http.jsonp(journalURL, { jsonpCallbackParam: 'callback' }).then(function (response) {
       newThumbnail = response.data.data["0"].coverImageUrl;
     }, function (error) {


### PR DESCRIPTION
This is the current best practice way for Primo instances to integrate with the Third Iron API.

Also changed the endpoints to match what the apiconnector server uses.

Simply replace `your_browzine_library_id` and this should be ready to work with the Third Iron API Connector.